### PR TITLE
Fix nest 8.x.x compatability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,16 @@
 import { CustomTransportStrategy, MessageHandler, Server } from '@nestjs/microservices';
 import { IpcMainEvent } from 'electron';
 import { ipcMessageDispatcher } from './libs/event';
+import { Logger } from '@nestjs/common';
 
 export interface IPCContext {
-	evt: IpcMainEvent
+	evt: IpcMainEvent;
 }
 
 export class ElectronIPCTransport extends Server implements CustomTransportStrategy {
+
+	logger = new Logger(ElectronIPCTransport.name);
+
 	async onMessage(messageChannel: string, ...args: any[]): Promise<any> {
 		const handler: MessageHandler | undefined = this.messageHandlers.get(messageChannel);
 		if (handler) {
@@ -24,7 +28,6 @@ export class ElectronIPCTransport extends Server implements CustomTransportStrat
 	}
 
 	listen(callback: () => void): any {
-		this.logger.setContext(ElectronIPCTransport.name);
 		ipcMessageDispatcher.on('ipc-message', this.onMessage.bind(this));
 		callback();
 	}


### PR DESCRIPTION
Due to [breaking changes in v8 of NestJS](https://docs.nestjs.com/migration-guide#logger-breaking-changes) the method setContext, is no longer present on the LoggerService that Server exposes.

To fix this we can set the logger context at initialization.
This should be backwards compatible with 7.x.x as well.


